### PR TITLE
Pass arguments to launch scripts

### DIFF
--- a/launch
+++ b/launch
@@ -1,2 +1,1 @@
-python wwwsearch/manage.py runserver
-
+python wwwsearch/manage.py runserver $@

--- a/lsolr
+++ b/lsolr
@@ -1,1 +1,1 @@
-./solr/solr-6.6.0/bin/solr start
+./solr/solr-6.6.0/bin/solr $@


### PR DESCRIPTION
This passes arguments to the two launch scripts through to the applications themselves. So to launch Searchbox open to external access you could now do:

    $ ./launch 0:8000

And to start Solr:

    $ ./lsolr start

A bit longer, but that means we can use the same script for stopping it:

    $ ./lsolr stop

I'll update the wiki with these instructions after merging.